### PR TITLE
bug/ iOS retain cycles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,11 +537,6 @@
             <artifactId>velocity</artifactId>
             <version>1.7</version>
           </dependency>
-          <dependency>
-            <groupId>com.google.j2objc</groupId>
-            <artifactId>j2objc-annotations</artifactId>
-            <version>1.1</version>
-          </dependency>
         </dependencies>
       </plugin>
       <!-- Setup to deploy site to GitHub, invoked with mvn site-deploy -->
@@ -761,6 +756,11 @@
       <artifactId>junit</artifactId>
       <version>3.8.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.j2objc</groupId>
+      <artifactId>j2objc-annotations</artifactId>
+      <version>1.1</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,11 @@
             <artifactId>velocity</artifactId>
             <version>1.7</version>
           </dependency>
+          <dependency>
+            <groupId>com.google.j2objc</groupId>
+            <artifactId>j2objc-annotations</artifactId>
+            <version>1.1</version>
+          </dependency>
         </dependencies>
       </plugin>
       <!-- Setup to deploy site to GitHub, invoked with mvn site-deploy -->

--- a/src/main/java/org/joda/time/format/DateTimeParserBucket.java
+++ b/src/main/java/org/joda/time/format/DateTimeParserBucket.java
@@ -18,6 +18,8 @@ package org.joda.time.format;
 import java.util.Arrays;
 import java.util.Locale;
 
+import com.google.j2objc.annotations.WeakOuter;
+
 import org.joda.time.Chronology;
 import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeFieldType;
@@ -509,6 +511,7 @@ public class DateTimeParserBucket {
         }
     }
 
+    @WeakOuter
     class SavedState {
         final DateTimeZone iZone;
         final Integer iOffset;

--- a/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
+++ b/src/main/java/org/joda/time/tz/CachedDateTimeZone.java
@@ -15,6 +15,8 @@
  */
 package org.joda.time.tz;
 
+import com.google.j2objc.annotations.WeakOuter;
+import com.google.j2objc.annotations.Weak;
 import org.joda.time.DateTimeZone;
 
 /**
@@ -166,10 +168,11 @@ public class CachedDateTimeZone extends DateTimeZone {
         return info;
     }
 
+    @WeakOuter
     private final static class Info {
         // For first Info in chain, iPeriodStart's lower 32 bits are clear.
         public final long iPeriodStart;
-        public final DateTimeZone iZoneRef;
+        @Weak public final DateTimeZone iZoneRef;
 
         Info iNextInfo;
 


### PR DESCRIPTION
We've added j2objc annotation dependency in order to mark some properties with `@Weak` annotation. This helps us resolve some of the retain cycles we've been seeing on iOS.

Trello card: https://trello.com/c/aRhqvXzR
Related Core PR: https://github.com/thefabulous/fabulous-core/pull/1430